### PR TITLE
Allow recoloring an existing named biome in place

### DIFF
--- a/core/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler.java
+++ b/core/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler.java
@@ -2,15 +2,18 @@ package io.github.lumine1909.custombiomecolors.nms;
 
 import io.github.lumine1909.custombiomecolors.object.BiomeData;
 import io.github.lumine1909.custombiomecolors.object.BiomeKey;
+import io.github.lumine1909.custombiomecolors.object.ColorData;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.RegistrationInfo;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.CraftWorld;
 
 import java.util.Collection;
 import java.util.IdentityHashMap;
+import java.util.function.Function;
 
 import static io.github.lumine1909.custombiomecolors.util.Reflection.*;
 
@@ -23,6 +26,34 @@ public interface ServerDataHandler<Biome, Holder, ResourceKey> extends ExtraData
     boolean hasBiome(BiomeKey biomeKey);
 
     BiomeAccessor<Biome, Holder, ResourceKey> createCustomBiome(BiomeData biomeData);
+
+    BiomeSpecialEffects buildSpecialEffects(ColorData colorData);
+
+    BiomeAccessor<Biome, Holder, ResourceKey> rewrapAccessor(Holder biomeBase, BiomeData data);
+
+    default void applyAttributeColors(Biome biome, ColorData colorData) {
+    }
+
+    /**
+     * Recolors an already-registered custom biome in place instead of registering a new
+     * biome under a new id. Keeps the same Holder/registry entry so blocks already using
+     * this biome, and players who join after this call, see the updated colors without the
+     * plugin needing to mint a new dynamic biome (which would need a client rejoin to sync
+     * and would otherwise make the plugin fall back to vanilla Plains for the current session,
+     * see PacketHandler#getModifiedId).
+     */
+    @SuppressWarnings("unchecked")
+    default BiomeAccessor<Biome, Holder, ResourceKey> updateBiomeColor(BiomeKey biomeKey, Function<ColorData.Builder, ColorData.Builder> colorChanger) {
+        BiomeAccessor<Biome, Holder, ResourceKey> accessor = getBiomeFromKey(biomeKey);
+        ColorData newColorData = colorChanger.apply(accessor.getBiomeData().colorData().mutable()).build();
+        Biome biome = accessor.getBiome();
+
+        field$Biome$specialEffects.set(biome, buildSpecialEffects(newColorData));
+        applyAttributeColors(biome, newColorData);
+
+        BiomeData newData = new BiomeData(biomeKey, accessor.getBiomeData().baseBiomeKey(), newColorData);
+        return rewrapAccessor(accessor.getBiomeHolder(), newData);
+    }
 
     @SuppressWarnings("unchecked")
     default void setBiomeAt(Location location, BiomeAccessor<Biome, Holder, ResourceKey> biomeAccessor) {

--- a/core/src/main/java/io/github/lumine1909/custombiomecolors/util/Reflection.java
+++ b/core/src/main/java/io/github/lumine1909/custombiomecolors/util/Reflection.java
@@ -17,6 +17,9 @@ public class Reflection {
     public static final Class<?> class$ClientboundLevelChunkPacketData = clazz("net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData");
     public static final Class<?> class$LevelChunkSection = clazz("net.minecraft.world.level.chunk.LevelChunkSection");
     public static final Class<?> class$Holder$Reference = clazz("net.minecraft.core.Holder$Reference");
+    public static final Class<?> class$Biome = clazz("net.minecraft.world.level.biome.Biome");
+    public static final Field<Object> field$Biome$specialEffects = Field.of(class$Biome, "specialEffects");
+    public static final Field<Object> field$Biome$attributes = Field.of(class$Biome, "attributes", 1);
     public static final Field<Boolean> field$MappedRegistry$frozen = Field.of(class$MappedRegistry, "frozen");
     public static final Field<Map<?, ?>> field$MappedRegistry$unregisteredIntrusiveHolders = Field.of(class$MappedRegistry, "unregisteredIntrusiveHolders");
     public static final Field<?> field$PalettedContainer$data = Field.of(class$PalettedContainer, "data");

--- a/nms/nms_1_20_5/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_20_5.java
+++ b/nms/nms_1_20_5/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_20_5.java
@@ -61,6 +61,13 @@ public class ServerDataHandler_1_20_5 implements ServerDataHandler<Biome, Holder
             .downfall(biome.climateSettings.downfall())
             .temperatureAdjustment(biome.climateSettings.temperatureModifier());
 
+        biomeBuilder.specialEffects(buildSpecialEffects(colorData));
+        Biome customBiome = biomeBuilder.build();
+        return new BiomeAccessor_1_20_5(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    }
+
+    @Override
+    public BiomeSpecialEffects buildSpecialEffects(ColorData colorData) {
         BiomeSpecialEffects.Builder builder = new BiomeSpecialEffects.Builder();
         builder.grassColorModifier(BiomeSpecialEffects.GrassColorModifier.NONE)
             .waterColor(colorData.get(ColorType.WATER))
@@ -69,10 +76,12 @@ public class ServerDataHandler_1_20_5 implements ServerDataHandler<Biome, Holder
             .fogColor(colorData.get(ColorType.FOG));
         colorData.apply(ColorType.GRASS, builder::grassColorOverride);
         colorData.apply(ColorType.FOLIAGE, builder::foliageColorOverride);
+        return builder.build();
+    }
 
-        biomeBuilder.specialEffects(builder.build());
-        Biome customBiome = biomeBuilder.build();
-        return new BiomeAccessor_1_20_5(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    @Override
+    public BiomeAccessor<Biome, Holder<Biome>, ResourceKey<Biome>> rewrapAccessor(Holder<Biome> biomeBase, BiomeData data) {
+        return new BiomeAccessor_1_20_5(biomeBase, data);
     }
 
     @Override

--- a/nms/nms_1_21/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_21.java
+++ b/nms/nms_1_21/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_21.java
@@ -61,6 +61,13 @@ public class ServerDataHandler_1_21 implements ServerDataHandler<Biome, Holder<B
             .downfall(biome.climateSettings.downfall())
             .temperatureAdjustment(biome.climateSettings.temperatureModifier());
 
+        biomeBuilder.specialEffects(buildSpecialEffects(colorData));
+        Biome customBiome = biomeBuilder.build();
+        return new BiomeAccessor_1_21(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    }
+
+    @Override
+    public BiomeSpecialEffects buildSpecialEffects(ColorData colorData) {
         BiomeSpecialEffects.Builder builder = new BiomeSpecialEffects.Builder();
         builder.grassColorModifier(BiomeSpecialEffects.GrassColorModifier.NONE)
             .waterColor(colorData.get(ColorType.WATER))
@@ -69,10 +76,12 @@ public class ServerDataHandler_1_21 implements ServerDataHandler<Biome, Holder<B
             .fogColor(colorData.get(ColorType.FOG));
         colorData.apply(ColorType.GRASS, builder::grassColorOverride);
         colorData.apply(ColorType.FOLIAGE, builder::foliageColorOverride);
+        return builder.build();
+    }
 
-        biomeBuilder.specialEffects(builder.build());
-        Biome customBiome = biomeBuilder.build();
-        return new BiomeAccessor_1_21(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    @Override
+    public BiomeAccessor<Biome, Holder<Biome>, ResourceKey<Biome>> rewrapAccessor(Holder<Biome> biomeBase, BiomeData data) {
+        return new BiomeAccessor_1_21(biomeBase, data);
     }
 
     @Override

--- a/nms/nms_1_21_11/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_21_11.java
+++ b/nms/nms_1_21_11/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_21_11.java
@@ -24,6 +24,8 @@ import org.bukkit.craftbukkit.CraftWorld;
 import java.util.Collection;
 import java.util.Map;
 
+import static io.github.lumine1909.custombiomecolors.util.Reflection.*;
+
 public class ServerDataHandler_1_21_11 implements ServerDataHandler<Biome, Holder<Biome>, ResourceKey<Biome>> {
 
     static final Map<ColorType, EnvironmentAttribute<Integer>> COLOR_ATTRIBUTE = Map.of(
@@ -78,22 +80,42 @@ public class ServerDataHandler_1_21_11 implements ServerDataHandler<Biome, Holde
             .downfall(biome.climateSettings.downfall())
             .temperatureAdjustment(biome.climateSettings.temperatureModifier());
 
+        biomeBuilder.specialEffects(buildSpecialEffects(colorData));
+        EnvironmentAttributeMap.Builder attributesBuilder = buildAttributesBuilder(biome, colorData);
+        biomeBuilder.putAttributes(attributesBuilder);
+        Biome customBiome = biomeBuilder.build();
+
+        return new BiomeAccessor_1_21_11(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    }
+
+    @Override
+    public BiomeSpecialEffects buildSpecialEffects(ColorData colorData) {
         BiomeSpecialEffects.Builder builder = new BiomeSpecialEffects.Builder();
         builder.grassColorModifier(BiomeSpecialEffects.GrassColorModifier.NONE).waterColor(colorData.get(ColorType.WATER));
         colorData.apply(ColorType.GRASS, builder::grassColorOverride);
         colorData.apply(ColorType.FOLIAGE, builder::foliageColorOverride);
         colorData.apply(ColorType.DRY_FOLIAGE, builder::dryFoliageColorOverride);
-        biomeBuilder.specialEffects(builder.build());
+        return builder.build();
+    }
+
+    private EnvironmentAttributeMap.Builder buildAttributesBuilder(Biome biome, ColorData colorData) {
         EnvironmentAttributeMap.Builder attributesBuilder = EnvironmentAttributeMap.builder().putAll(biome.getAttributes());
         COLOR_ATTRIBUTE.forEach((color, attribute) -> {
             EnvironmentAttributeMap.Entry<Integer, ?> entry = biome.getAttributes().get(attribute);
             Integer defaultValue = entry == null ? null : entry.applyModifier(0);
             colorData.apply(color, v -> attributesBuilder.set(attribute, v), defaultValue);
         });
-        biomeBuilder.putAttributes(attributesBuilder);
-        Biome customBiome = biomeBuilder.build();
+        return attributesBuilder;
+    }
 
-        return new BiomeAccessor_1_21_11(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    @Override
+    public void applyAttributeColors(Biome biome, ColorData colorData) {
+        field$Biome$attributes.set(biome, buildAttributesBuilder(biome, colorData).build());
+    }
+
+    @Override
+    public BiomeAccessor<Biome, Holder<Biome>, ResourceKey<Biome>> rewrapAccessor(Holder<Biome> biomeBase, BiomeData data) {
+        return new BiomeAccessor_1_21_11(biomeBase, data);
     }
 
     @Override

--- a/nms/nms_1_21_3/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_21_3.java
+++ b/nms/nms_1_21_3/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_21_3.java
@@ -61,6 +61,13 @@ public class ServerDataHandler_1_21_3 implements ServerDataHandler<Biome, Holder
             .downfall(biome.climateSettings.downfall())
             .temperatureAdjustment(biome.climateSettings.temperatureModifier());
 
+        biomeBuilder.specialEffects(buildSpecialEffects(colorData));
+        Biome customBiome = biomeBuilder.build();
+        return new BiomeAccessor_1_21_3(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    }
+
+    @Override
+    public BiomeSpecialEffects buildSpecialEffects(ColorData colorData) {
         BiomeSpecialEffects.Builder builder = new BiomeSpecialEffects.Builder();
         builder.grassColorModifier(BiomeSpecialEffects.GrassColorModifier.NONE)
             .waterColor(colorData.get(ColorType.WATER))
@@ -69,12 +76,13 @@ public class ServerDataHandler_1_21_3 implements ServerDataHandler<Biome, Holder
             .fogColor(colorData.get(ColorType.FOG));
         colorData.apply(ColorType.GRASS, builder::grassColorOverride);
         colorData.apply(ColorType.FOLIAGE, builder::foliageColorOverride);
-
-        biomeBuilder.specialEffects(builder.build());
-        Biome customBiome = biomeBuilder.build();
-        return new BiomeAccessor_1_21_3(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+        return builder.build();
     }
 
+    @Override
+    public BiomeAccessor<Biome, Holder<Biome>, ResourceKey<Biome>> rewrapAccessor(Holder<Biome> biomeBase, BiomeData data) {
+        return new BiomeAccessor_1_21_3(biomeBase, data);
+    }
 
     @Override
     public MappedRegistry<Biome> getRegistry() {

--- a/nms/nms_1_21_4/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_21_4.java
+++ b/nms/nms_1_21_4/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_21_4.java
@@ -61,6 +61,13 @@ public class ServerDataHandler_1_21_4 implements ServerDataHandler<Biome, Holder
             .downfall(biome.climateSettings.downfall())
             .temperatureAdjustment(biome.climateSettings.temperatureModifier());
 
+        biomeBuilder.specialEffects(buildSpecialEffects(colorData));
+        Biome customBiome = biomeBuilder.build();
+        return new BiomeAccessor_1_21_4(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    }
+
+    @Override
+    public BiomeSpecialEffects buildSpecialEffects(ColorData colorData) {
         BiomeSpecialEffects.Builder builder = new BiomeSpecialEffects.Builder();
         builder.grassColorModifier(BiomeSpecialEffects.GrassColorModifier.NONE)
             .waterColor(colorData.get(ColorType.WATER))
@@ -69,10 +76,12 @@ public class ServerDataHandler_1_21_4 implements ServerDataHandler<Biome, Holder
             .fogColor(colorData.get(ColorType.FOG));
         colorData.apply(ColorType.GRASS, builder::grassColorOverride);
         colorData.apply(ColorType.FOLIAGE, builder::foliageColorOverride);
+        return builder.build();
+    }
 
-        biomeBuilder.specialEffects(builder.build());
-        Biome customBiome = biomeBuilder.build();
-        return new BiomeAccessor_1_21_4(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    @Override
+    public BiomeAccessor<Biome, Holder<Biome>, ResourceKey<Biome>> rewrapAccessor(Holder<Biome> biomeBase, BiomeData data) {
+        return new BiomeAccessor_1_21_4(biomeBase, data);
     }
 
     @Override

--- a/nms/nms_1_21_5/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_21_5.java
+++ b/nms/nms_1_21_5/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_21_5.java
@@ -61,6 +61,13 @@ public class ServerDataHandler_1_21_5 implements ServerDataHandler<Biome, Holder
             .downfall(biome.climateSettings.downfall())
             .temperatureAdjustment(biome.climateSettings.temperatureModifier());
 
+        biomeBuilder.specialEffects(buildSpecialEffects(colorData));
+        Biome customBiome = biomeBuilder.build();
+        return new BiomeAccessor_1_21_5(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    }
+
+    @Override
+    public BiomeSpecialEffects buildSpecialEffects(ColorData colorData) {
         BiomeSpecialEffects.Builder builder = new BiomeSpecialEffects.Builder();
         builder.grassColorModifier(BiomeSpecialEffects.GrassColorModifier.NONE)
             .waterColor(colorData.get(ColorType.WATER))
@@ -70,10 +77,12 @@ public class ServerDataHandler_1_21_5 implements ServerDataHandler<Biome, Holder
         colorData.apply(ColorType.GRASS, builder::grassColorOverride);
         colorData.apply(ColorType.FOLIAGE, builder::foliageColorOverride);
         colorData.apply(ColorType.DRY_FOLIAGE, builder::dryFoliageColorOverride);
+        return builder.build();
+    }
 
-        biomeBuilder.specialEffects(builder.build());
-        Biome customBiome = biomeBuilder.build();
-        return new BiomeAccessor_1_21_5(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    @Override
+    public BiomeAccessor<Biome, Holder<Biome>, ResourceKey<Biome>> rewrapAccessor(Holder<Biome> biomeBase, BiomeData data) {
+        return new BiomeAccessor_1_21_5(biomeBase, data);
     }
 
     @Override

--- a/nms/nms_1_21_9/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_21_9.java
+++ b/nms/nms_1_21_9/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_1_21_9.java
@@ -61,6 +61,13 @@ public class ServerDataHandler_1_21_9 implements ServerDataHandler<Biome, Holder
             .downfall(biome.climateSettings.downfall())
             .temperatureAdjustment(biome.climateSettings.temperatureModifier());
 
+        biomeBuilder.specialEffects(buildSpecialEffects(colorData));
+        Biome customBiome = biomeBuilder.build();
+        return new BiomeAccessor_1_21_9(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    }
+
+    @Override
+    public BiomeSpecialEffects buildSpecialEffects(ColorData colorData) {
         BiomeSpecialEffects.Builder builder = new BiomeSpecialEffects.Builder();
         builder.grassColorModifier(BiomeSpecialEffects.GrassColorModifier.NONE)
             .waterColor(colorData.get(ColorType.WATER))
@@ -70,10 +77,12 @@ public class ServerDataHandler_1_21_9 implements ServerDataHandler<Biome, Holder
         colorData.apply(ColorType.GRASS, builder::grassColorOverride);
         colorData.apply(ColorType.FOLIAGE, builder::foliageColorOverride);
         colorData.apply(ColorType.DRY_FOLIAGE, builder::dryFoliageColorOverride);
+        return builder.build();
+    }
 
-        biomeBuilder.specialEffects(builder.build());
-        Biome customBiome = biomeBuilder.build();
-        return new BiomeAccessor_1_21_9(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    @Override
+    public BiomeAccessor<Biome, Holder<Biome>, ResourceKey<Biome>> rewrapAccessor(Holder<Biome> biomeBase, BiomeData data) {
+        return new BiomeAccessor_1_21_9(biomeBase, data);
     }
 
     @Override

--- a/nms/nms_26_1/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_26_1.java
+++ b/nms/nms_26_1/src/main/java/io/github/lumine1909/custombiomecolors/nms/ServerDataHandler_26_1.java
@@ -24,6 +24,8 @@ import org.bukkit.craftbukkit.CraftWorld;
 import java.util.Collection;
 import java.util.Map;
 
+import static io.github.lumine1909.custombiomecolors.util.Reflection.*;
+
 public class ServerDataHandler_26_1 implements ServerDataHandler<Biome, Holder<Biome>, ResourceKey<Biome>> {
 
     static final Map<ColorType, EnvironmentAttribute<Integer>> COLOR_ATTRIBUTE = Map.of(
@@ -78,23 +80,42 @@ public class ServerDataHandler_26_1 implements ServerDataHandler<Biome, Holder<B
             .downfall(biome.climateSettings.downfall())
             .temperatureAdjustment(biome.climateSettings.temperatureModifier());
 
+        biomeBuilder.specialEffects(buildSpecialEffects(colorData));
+        EnvironmentAttributeMap.Builder attributesBuilder = buildAttributesBuilder(biome, colorData);
+        biomeBuilder.putAttributes(attributesBuilder);
+        Biome customBiome = biomeBuilder.build();
+
+        return new BiomeAccessor_26_1(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    }
+
+    @Override
+    public BiomeSpecialEffects buildSpecialEffects(ColorData colorData) {
         BiomeSpecialEffects.Builder builder = new BiomeSpecialEffects.Builder();
         builder.grassColorModifier(BiomeSpecialEffects.GrassColorModifier.NONE).waterColor(colorData.get(ColorType.WATER));
         colorData.apply(ColorType.GRASS, builder::grassColorOverride);
         colorData.apply(ColorType.FOLIAGE, builder::foliageColorOverride);
         colorData.apply(ColorType.DRY_FOLIAGE, builder::dryFoliageColorOverride);
-        biomeBuilder.specialEffects(builder.build());
-        biomeBuilder.specialEffects(builder.build());
+        return builder.build();
+    }
+
+    private EnvironmentAttributeMap.Builder buildAttributesBuilder(Biome biome, ColorData colorData) {
         EnvironmentAttributeMap.Builder attributesBuilder = EnvironmentAttributeMap.builder().putAll(biome.getAttributes());
         COLOR_ATTRIBUTE.forEach((color, attribute) -> {
             EnvironmentAttributeMap.Entry<Integer, ?> entry = biome.getAttributes().get(attribute);
             Integer defaultValue = entry == null ? null : entry.applyModifier(0);
             colorData.apply(color, v -> attributesBuilder.set(attribute, v), defaultValue);
         });
-        biomeBuilder.putAttributes(attributesBuilder);
-        Biome customBiome = biomeBuilder.build();
+        return attributesBuilder;
+    }
 
-        return new BiomeAccessor_26_1(this.registerBiome(holder, customBiome, resourceKey), biomeData);
+    @Override
+    public void applyAttributeColors(Biome biome, ColorData colorData) {
+        field$Biome$attributes.set(biome, buildAttributesBuilder(biome, colorData).build());
+    }
+
+    @Override
+    public BiomeAccessor<Biome, Holder<Biome>, ResourceKey<Biome>> rewrapAccessor(Holder<Biome> biomeBase, BiomeData data) {
+        return new BiomeAccessor_26_1(biomeBase, data);
     }
 
     @Override

--- a/plugin/src/main/java/io/github/lumine1909/custombiomecolors/BiomeManager.java
+++ b/plugin/src/main/java/io/github/lumine1909/custombiomecolors/BiomeManager.java
@@ -12,6 +12,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,6 +27,22 @@ public class BiomeManager {
 
     public void changeBiomeColor(Player player, Region region, ColorType colorType, Integer color, Runnable runWhenDone) {
         this.changeBiomeColor(player, region, colorType, color, new BiomeKey("cbc", StringUtil.randomString(10)), false, runWhenDone);
+    }
+
+    /**
+     * Recolors an already-existing named biome in place (instead of registering a brand-new
+     * biome). If a region is given it's also assigned that biome, extending where it's used;
+     * a null region just updates the biome definition itself, with no selection required.
+     */
+    public void updateBiomeColor(Player player, @Nullable Region region, ColorType colorType, Integer color, BiomeKey biomeKey, Runnable runWhenDone) {
+        UnaryOperator<ColorData.Builder> colorChanger = builder -> builder.set(colorType, color);
+        BiomeAccessor updated = serverDataHandler.updateBiomeColor(biomeKey, colorChanger);
+        dataManager.saveBiome(biomeKey, updated.getBiomeData());
+        if (region == null) {
+            runWhenDone.run();
+            return;
+        }
+        CustomBiomeColors.getInstance().getWorldEditHandler().applyChange(player, region, loc -> updated, runWhenDone);
     }
 
     @SuppressWarnings("unchecked")

--- a/plugin/src/main/java/io/github/lumine1909/custombiomecolors/command/SetBiomeColorCommand.java
+++ b/plugin/src/main/java/io/github/lumine1909/custombiomecolors/command/SetBiomeColorCommand.java
@@ -16,6 +16,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -42,11 +43,6 @@ public record SetBiomeColorCommand(ColorType colorType) implements TabExecutor {
         if (args.length == 0) {
             return true;
         }
-        Region selectedRegion = worldEditHandler.getSelectedRegion(sender.getName());
-        if (selectedRegion == null) {
-            sender.sendMessage(Component.text("[CustomBiomeColors] Make a region selection first!", NamedTextColor.RED));
-            return true;
-        }
 
         Integer color;
         try {
@@ -57,22 +53,46 @@ public record SetBiomeColorCommand(ColorType colorType) implements TabExecutor {
         }
 
         long time = System.currentTimeMillis();
-        Runnable runWhenDone = () -> sender.sendMessage(Component.text("[CustomBiomeColors] Biome color was changed for approximately " + selectedRegion.getVolume() + " blocks. (" + (System.currentTimeMillis() - time) / 1000.0f + "s)", NamedTextColor.GREEN));
 
-        if (args.length == 1) {
-            CustomBiomeColors.getInstance().getBiomeManager().changeBiomeColor(player, selectedRegion, this.colorType, color, runWhenDone);
+        if (args.length >= 2) {
+            if (!args[1].contains(":")) {
+                sender.sendMessage(Component.text("[CustomBiomeColors] The biome name must contain a colon! ( : )", NamedTextColor.RED));
+                return true;
+            }
+            BiomeKey biomeKey = BiomeKey.fromString(args[1]);
+            if (CustomBiomeColors.getInstance().getDataManager().hasBiome(biomeKey)) {
+                // Recoloring an already-existing named biome doesn't need a selection:
+                // it updates the biome definition itself. If a selection happens to be
+                // active it's also painted with it, extending where the biome is used.
+                Region selectedRegion = worldEditHandler.getSelectedRegion(sender.getName());
+                Runnable runWhenDone = selectedRegion == null
+                    ? () -> sender.sendMessage(Component.text("[CustomBiomeColors] Biome '" + biomeKey + "' color was updated. (" + (System.currentTimeMillis() - time) / 1000.0f + "s)", NamedTextColor.GREEN))
+                    : () -> sender.sendMessage(Component.text("[CustomBiomeColors] Biome color was changed for approximately " + selectedRegion.getVolume() + " blocks. (" + (System.currentTimeMillis() - time) / 1000.0f + "s)", NamedTextColor.GREEN));
+                CustomBiomeColors.getInstance().getBiomeManager().updateBiomeColor(player, selectedRegion, this.colorType, color, biomeKey, runWhenDone);
+                return true;
+            }
+
+            Region selectedRegion = worldEditHandler.getSelectedRegion(sender.getName());
+            if (selectedRegion == null) {
+                sender.sendMessage(Component.text("[CustomBiomeColors] Make a region selection first!", NamedTextColor.RED));
+                return true;
+            }
+            if (BIOME_DATA_HANDLER.hasBiome(biomeKey)) {
+                sender.sendMessage(Component.text("[CustomBiomeColors] There is already exists a biome with that name, please use another one!", NamedTextColor.RED));
+                return true;
+            }
+            Runnable runWhenDone = () -> sender.sendMessage(Component.text("[CustomBiomeColors] Biome color was changed for approximately " + selectedRegion.getVolume() + " blocks. (" + (System.currentTimeMillis() - time) / 1000.0f + "s)", NamedTextColor.GREEN));
+            CustomBiomeColors.getInstance().getBiomeManager().changeBiomeColor(player, selectedRegion, this.colorType, color, biomeKey, true, runWhenDone);
             return true;
         }
-        if (!args[1].contains(":")) {
-            sender.sendMessage(Component.text("[CustomBiomeColors] The biome name must contain a colon! ( : )", NamedTextColor.RED));
+
+        Region selectedRegion = worldEditHandler.getSelectedRegion(sender.getName());
+        if (selectedRegion == null) {
+            sender.sendMessage(Component.text("[CustomBiomeColors] Make a region selection first!", NamedTextColor.RED));
             return true;
         }
-        BiomeKey biomeKey = BiomeKey.fromString(args[1]);
-        if (BIOME_DATA_HANDLER.hasBiome(biomeKey)) {
-            sender.sendMessage(Component.text("[CustomBiomeColors] There is already exists a biome with that name, please use another one!", NamedTextColor.RED));
-            return true;
-        }
-        CustomBiomeColors.getInstance().getBiomeManager().changeBiomeColor(player, selectedRegion, this.colorType, color, biomeKey, true, runWhenDone);
+        Runnable runWhenDone = () -> sender.sendMessage(Component.text("[CustomBiomeColors] Biome color was changed for approximately " + selectedRegion.getVolume() + " blocks. (" + (System.currentTimeMillis() - time) / 1000.0f + "s)", NamedTextColor.GREEN));
+        CustomBiomeColors.getInstance().getBiomeManager().changeBiomeColor(player, selectedRegion, this.colorType, color, runWhenDone);
         return true;
     }
 
@@ -81,7 +101,21 @@ public record SetBiomeColorCommand(ColorType colorType) implements TabExecutor {
         if (args.length == 1) {
             return List.of("#HEXCODE", "default");
         } else if (args.length == 2) {
-            return List.of("namespace:biomename");
+            List<String> suggestions = new ArrayList<>();
+            for (BiomeKey biomeKey : CustomBiomeColors.getInstance().getDataManager().getBiomeKeys()) {
+                suggestions.add(biomeKey.toString());
+            }
+            if (suggestions.isEmpty()) {
+                suggestions.add("namespace:biomename");
+            }
+            String partial = args[1].toLowerCase();
+            List<String> matches = new ArrayList<>();
+            for (String suggestion : suggestions) {
+                if (suggestion.toLowerCase().startsWith(partial)) {
+                    matches.add(suggestion);
+                }
+            }
+            return matches;
         }
         return Collections.emptyList();
     }

--- a/plugin/src/main/java/io/github/lumine1909/custombiomecolors/data/DataManager.java
+++ b/plugin/src/main/java/io/github/lumine1909/custombiomecolors/data/DataManager.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -69,6 +70,14 @@ public class DataManager {
     public void saveBiome(BiomeKey biomeKey, BiomeData biomeData) {
         this.biomeDataMap.put(biomeKey, biomeData);
         scheduleSave();
+    }
+
+    public boolean hasBiome(BiomeKey biomeKey) {
+        return this.biomeDataMap.containsKey(biomeKey);
+    }
+
+    public Set<BiomeKey> getBiomeKeys() {
+        return this.biomeDataMap.keySet();
     }
 
     private Future<?> scheduleSave() {


### PR DESCRIPTION
## Summary

Currently, naming a biome that already exists (`//setXcolor #hex <name>`) errors out with "There is already exists a biome with that name, please use another one!". That forces every color edit on a named biome to mint a brand-new biome + registry entry, which:
- grows the dynamic biome registry forever, and
- means already-connected players fall back to vanilla Plains for that block until they rejoin, since the new biome id isn't in their client's registry snapshot from login (see `PacketHandler#getModifiedId`).

This PR lets `//setXcolor <hex> <existing-name>` recolor that biome's already-registered definition in place (via reflection on `Biome.specialEffects`, and on 1.21.11/26.1 also `Biome.attributes`) instead of always creating a new one. It keeps the same registry id, so new joiners see it correctly and the registry doesn't grow on every edit.

- A region selection is now only required when creating a *new* named biome (or the no-name form). Recoloring an existing named biome works with no selection, and also paints the current selection with it if one is active.
- Tab-complete on the biome-name argument now suggests biome names the plugin has already created (from `data.json`), instead of only the static `namespace:biomename` placeholder.
- Guarded against collisions: the "biome already exists" check is against biomes *this plugin* created (`DataManager`'s own saved data), not just any registered biome name, so this can't accidentally target/overwrite a real vanilla or mod biome that happens to share the chosen name.

**Known limitation (not fixed by this PR, just made less frequent):** players already connected when a recolor happens still need to rejoin to see it, since there's no vanilla packet to hot-patch a dynamic registry entry the client already cached at login.

## Test plan

- [ ] Built successfully across all 8 NMS targets (1.20.5, 1.21, 1.21.3, 1.21.4, 1.21.5, 1.21.9, 1.21.11, 26.1) via `./gradlew shadowJar`.
- [ ] **Not yet tested against a live server** — field names for the reflection (`specialEffects`, `attributes`) were verified by decompiling Paper's own mapped sources, but I don't have a running Paper instance across all these versions to confirm behavior in-game. Would appreciate a look before merging, especially the 1.21.11/26.1 attribute-map path.